### PR TITLE
Feature/sentence mining improvements

### DIFF
--- a/src/ConsoleMain.java
+++ b/src/ConsoleMain.java
@@ -38,6 +38,7 @@ public class ConsoleMain extends Main {
             println(out, "\t-p: disable punctuation filter");
             println(out, "\t-k: kanji words onlyfilter");
             println(out, "\t-r: Include furigana reading with sentence");
+            println(out, "\t-rc: Also include cloze html tags to mark the keyword in the sentence");
             println(out, "\t-c: count lines and export index of the first line a term shows up in");
             println(out, "\t-a: Append original line of the first time a term shows up in");
             println(out, "\t-l: pull out spellings to additional columns (merge respellings of words)");
@@ -60,6 +61,7 @@ public class ConsoleMain extends Main {
                 if(argument.equals("-s")) skip_furigana_formatting = true;
                 if(argument.equals("-k")) filter_kanji_only = true;
                 if(argument.equals("-r")) enable_sentence_reading = true;
+                if(argument.equals("-rc")) enable_sentence_reading_cloze = true;
                 if(argument.equals("-c")) enable_linecounter = true;
                 if(argument.equals("-a")) enable_append_line = true;
                 if(argument.equals("-l")) pull_out_spellings = true;

--- a/src/ConsoleMain.java
+++ b/src/ConsoleMain.java
@@ -1,6 +1,8 @@
 import java.io.*;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /*
  * Licensed under a public domain‐like license. See Main.java for license text.
@@ -28,12 +30,16 @@ public class ConsoleMain extends Main {
         {
             println(out, "Usage: java -jar analyzer.jar <corpus.txt> (-[fdswlpn] )*");
             println(out, "\tcorpus.txt: must be in utf-8. cannot be named \"-h\" or \"--help\".");
+            println(out, "\t-iX: index of sentence for TSV input");
             println(out, "\t-f: disable user filters (userfilters.csv)");
             println(out, "\t-d: disable user dictionary (userdict.csv)");
             println(out, "\t-s: strip 〈〉 (but not their contents) and enable 《》 furigana culling (incl. contents) (operates at the code unit level, before parsing)");
             println(out, "\t-w: disable 'only in dictionary' filter");
             println(out, "\t-p: disable punctuation filter");
+            println(out, "\t-k: kanji words onlyfilter");
+            println(out, "\t-r: Include furigana reading with sentence");
             println(out, "\t-c: count lines and export index of the first line a term shows up in");
+            println(out, "\t-a: Append original line of the first time a term shows up in");
             println(out, "\t-l: pull out spellings to additional columns (merge respellings of words)");
             println(out, "\t-x: lexmee mode (pull out spellings, pronunciations, and accents, overrides/replaces -l)");
             println(out, "Options must be stated separately (-p -d), not bundled (-pd)");
@@ -52,9 +58,18 @@ public class ConsoleMain extends Main {
                 if(argument.equals("-f")) enable_userfilter = false;
                 if(argument.equals("-d")) enable_userdictionary = false;
                 if(argument.equals("-s")) skip_furigana_formatting = true;
+                if(argument.equals("-k")) filter_kanji_only = true;
+                if(argument.equals("-r")) enable_sentence_reading = true;
                 if(argument.equals("-c")) enable_linecounter = true;
+                if(argument.equals("-a")) enable_append_line = true;
                 if(argument.equals("-l")) pull_out_spellings = true;
                 if(argument.equals("-x")) lexeme_only = true;
+                if(argument.matches("^-i\\d+$")) {
+                    Pattern pattern = Pattern.compile("^-i(\\d+)$");
+                    Matcher matcher = pattern.matcher(argument);
+                    matcher.find();
+                    sentence_index = Integer.parseInt(matcher.group(1));
+                }
             }
             try
             {

--- a/src/ConsoleMain.java
+++ b/src/ConsoleMain.java
@@ -76,6 +76,8 @@ public class ConsoleMain extends Main {
             }
             catch(IOException e)
             { /**/ }
+            catch(Exception e)
+            { /**/ }
         }
         try
         {

--- a/src/GUIMain.java
+++ b/src/GUIMain.java
@@ -1,6 +1,5 @@
 import javax.swing.*;
 import java.awt.*;
-import java.awt.image.*;
 import java.io.*;
 import java.util.function.BiFunction;
 
@@ -15,9 +14,12 @@ public class GUIMain extends Main {
 
     static private JCheckBox option_enable_filter_dictionary;
     static private JCheckBox option_enable_filter_punctuation;
+    static private JCheckBox option_enable_filter_kanji_only;
 
     static private JCheckBox option_strip_furigana;
+    static private JCheckBox option_enable_sentence_reading;
     static private JCheckBox option_enable_linecount;
+    static private JCheckBox option_append_line;
     static private JCheckBox option_enable_userdict;
     static private JCheckBox option_enable_userfilter;
     
@@ -48,18 +50,24 @@ public class GUIMain extends Main {
 
             JLabel explanation2 = new JLabel("Input must be in UTF-8.");
             JButton input = new JButton("Input");
+            JLabel sentence_index_explanation = new JLabel("Index of sentence for TSV input:");
+
             JButton write = new JButton("Output");
             JTextField field_input = new JTextField("");
+            JTextField field_sentence_index_input = new JTextField("-1");
             JTextField field_write = new JTextField("");
 
             JLabel explanation3 = new JLabel("Filters:");
             option_enable_filter_dictionary = new JCheckBox("Require term to be in dictionary", true);
             option_enable_filter_punctuation = new JCheckBox("Disallow punctuation", true);
             option_enable_userfilter = new JCheckBox("Load filters from userfilter.csv", true);
+            option_enable_filter_kanji_only = new JCheckBox("Kanji words only", false);
 
             JLabel explanation4 = new JLabel("Other options:");
             option_strip_furigana = new JCheckBox("Strip 《》 furigana (occurs before parsing) (also deletes 〈 and 〉)", false);
+            option_enable_sentence_reading = new JCheckBox("Include sentence with furigana reading and close html tags for keyword", false);
             option_enable_linecount = new JCheckBox("Include index of line of first occurrence", false);
+            option_append_line = new JCheckBox("Append entire line of first occurrence", false);
             option_enable_userdict = new JCheckBox("Load additional user dictionary from userdict.csv", true);
             
             JLabel explanation5 = new JLabel("What makes a word unique:");
@@ -94,13 +102,17 @@ public class GUIMain extends Main {
             {
                 filter_dictionary_enabled = option_enable_filter_dictionary.isSelected();
                 filter_punctuation_enabled = option_enable_filter_punctuation.isSelected();
+                filter_kanji_only = option_enable_filter_kanji_only.isSelected();
 
                 skip_furigana_formatting = option_strip_furigana.isSelected();
+                enable_sentence_reading = option_enable_sentence_reading.isSelected();
                 enable_linecounter = option_enable_linecount.isSelected();
+                enable_append_line = option_append_line.isSelected();
                 
                 enable_userdictionary = option_enable_userdict.isSelected();
                 enable_userfilter = option_enable_userfilter.isSelected();
                 
+
                 pull_out_spellings = option_respelling_mode.getSelectedItem().equals("Pronunciation");
                 lexeme_only = option_respelling_mode.getSelectedItem().equals("Lexeme");
 
@@ -109,6 +121,7 @@ public class GUIMain extends Main {
                 {
                     try
                     {
+                        sentence_index = Integer.parseInt(field_sentence_index_input.getText());
                         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(field_write.getText()), "UTF-8"));
                         run(field_input.getText(), writer, (text, length) ->
                         {
@@ -143,6 +156,14 @@ public class GUIMain extends Main {
                     {
                         progress.setString("Error while closing output file.");
                     }
+                    catch (NumberFormatException e)
+                    {
+                        progress.setString("Invalid sentence index.");
+                    }
+                    catch (Exception e)
+                    {
+                        progress.setString(e.toString());
+                    }
                 });
                 worker.start();
             });
@@ -160,16 +181,23 @@ public class GUIMain extends Main {
 
             row = adder.apply(explanation2, row); row += 5;
             input.setBounds(5, row, 65, 20); field_input.setBounds(75, row, pane.getWidth()-75-10, 20); row += 25;
+
+
+            sentence_index_explanation.setBounds(5, row, 160, 20); field_sentence_index_input.setBounds(165, row, 30, 20);   row += 25;
+
             write.setBounds(5, row, 65, 20); field_write.setBounds(75, row, pane.getWidth()-75-10, 20); row += 25;
 
-            row += 3; row = adder.apply(explanation3, row); row += 3;
+            row += 4; row = adder.apply(explanation3, row); row += 4;
             row = adder.apply(option_enable_filter_dictionary, row);
             row = adder.apply(option_enable_filter_punctuation, row);
+            row = adder.apply(option_enable_filter_kanji_only, row);
             row = adder.apply(option_enable_userfilter, row);
 
-            row += 3; row = adder.apply(explanation4, row); row += 3;
+            row += 5; row = adder.apply(explanation4, row); row += 5;
             row = adder.apply(option_strip_furigana, row);
+            row = adder.apply(option_enable_sentence_reading, row);
             row = adder.apply(option_enable_linecount, row);
+            row = adder.apply(option_append_line, row);
             row = adder.apply(option_enable_userdict, row);
             explanation5.setBounds(5, row, 150, 20); option_respelling_mode.setBounds(160, row, 150, 20); row += 25;
             row += 5;
@@ -179,20 +207,25 @@ public class GUIMain extends Main {
 
             pane.add(explanation1);
             pane.add(explanation2);
+            pane.add(sentence_index_explanation);
             pane.add(explanation3);
             pane.add(explanation4);
 
             pane.add(input);
             pane.add(write);
             pane.add(field_input);
+            pane.add(field_sentence_index_input);
             pane.add(field_write);
 
             pane.add(option_enable_filter_dictionary);
             pane.add(option_enable_filter_punctuation);
             pane.add(option_enable_userfilter);
+            pane.add(option_enable_filter_kanji_only);
 
             pane.add(option_strip_furigana);
+            pane.add(option_enable_sentence_reading);
             pane.add(option_enable_linecount);
+            pane.add(option_append_line);
             pane.add(option_enable_userdict);
             pane.add(explanation5);
             pane.add(option_respelling_mode);

--- a/src/GUIMain.java
+++ b/src/GUIMain.java
@@ -18,6 +18,7 @@ public class GUIMain extends Main {
 
     static private JCheckBox option_strip_furigana;
     static private JCheckBox option_enable_sentence_reading;
+    static private JCheckBox option_enable_sentence_reading_cloze;
     static private JCheckBox option_enable_linecount;
     static private JCheckBox option_append_line;
     static private JCheckBox option_enable_userdict;
@@ -65,7 +66,9 @@ public class GUIMain extends Main {
 
             JLabel explanation4 = new JLabel("Other options:");
             option_strip_furigana = new JCheckBox("Strip 《》 furigana (occurs before parsing) (also deletes 〈 and 〉)", false);
-            option_enable_sentence_reading = new JCheckBox("Include sentence with furigana reading and close html tags for keyword", false);
+            option_enable_sentence_reading = new JCheckBox("Include sentence with furigana reading", false);
+            option_enable_sentence_reading_cloze = new JCheckBox("Also include cloze html tags to mark the keyword in the sentence", false);
+            option_enable_sentence_reading_cloze.setMargin(new Insets(0,20,0,0));
             option_enable_linecount = new JCheckBox("Include index of line of first occurrence", false);
             option_append_line = new JCheckBox("Append entire line of first occurrence", false);
             option_enable_userdict = new JCheckBox("Load additional user dictionary from userdict.csv", true);
@@ -106,6 +109,7 @@ public class GUIMain extends Main {
 
                 skip_furigana_formatting = option_strip_furigana.isSelected();
                 enable_sentence_reading = option_enable_sentence_reading.isSelected();
+                enable_sentence_reading_cloze = option_enable_sentence_reading_cloze.isSelected();
                 enable_linecounter = option_enable_linecount.isSelected();
                 enable_append_line = option_append_line.isSelected();
                 
@@ -193,9 +197,10 @@ public class GUIMain extends Main {
             row = adder.apply(option_enable_filter_kanji_only, row);
             row = adder.apply(option_enable_userfilter, row);
 
-            row += 5; row = adder.apply(explanation4, row); row += 5;
+            row += 6; row = adder.apply(explanation4, row); row += 6;
             row = adder.apply(option_strip_furigana, row);
             row = adder.apply(option_enable_sentence_reading, row);
+            row = adder.apply(option_enable_sentence_reading_cloze, row);
             row = adder.apply(option_enable_linecount, row);
             row = adder.apply(option_append_line, row);
             row = adder.apply(option_enable_userdict, row);
@@ -224,6 +229,7 @@ public class GUIMain extends Main {
 
             pane.add(option_strip_furigana);
             pane.add(option_enable_sentence_reading);
+            pane.add(option_enable_sentence_reading_cloze);
             pane.add(option_enable_linecount);
             pane.add(option_append_line);
             pane.add(option_enable_userdict);

--- a/src/Main.java
+++ b/src/Main.java
@@ -59,6 +59,8 @@ public class Main
     static int sentence_index = -1;
     static boolean enable_append_line = false;
     static boolean enable_sentence_reading = false;
+    static boolean enable_sentence_reading_cloze = false;
+
 
     static boolean pull_out_spellings = false;
     static boolean lexeme_only = false;
@@ -327,11 +329,11 @@ public class Main
                     {
                         StringBuilder word = new StringBuilder();
                         boolean isCurrentToken = token.getSurface() == clozeToken.getSurface();
-                        if (isCurrentToken) {
+                        if (enable_sentence_reading_cloze && isCurrentToken) {
                             word.append("<span class=\"cloze\">");
                         }
                         word.append(Utils.toFurigana(clozeToken));
-                        if (isCurrentToken) {
+                        if (enable_sentence_reading_cloze && isCurrentToken) {
                             word.append("</span>");
                         }
 

--- a/src/Utils.java
+++ b/src/Utils.java
@@ -1,0 +1,21 @@
+public class Utils {
+
+    /**
+     * Translates this character into the equivalent Hiragana character.
+     * The function only operates on Katakana characters
+     * If the character is outside the Full width or Half width
+     * Katakana then the origianal character is returned.
+     */
+    public static char toHiragana(char c) {
+        return (char) (c - 0x60);
+    }
+
+    public static String toHiragana(String s) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            result.append(toHiragana(s.charAt(i)));
+        }
+        return result.toString();
+    }
+
+}

--- a/src/Utils.java
+++ b/src/Utils.java
@@ -1,3 +1,5 @@
+import com.atilika.kuromoji.unidic.kanaaccent.Token;
+
 public class Utils {
 
     /**
@@ -16,6 +18,32 @@ public class Utils {
             result.append(toHiragana(s.charAt(i)));
         }
         return result.toString();
+    }
+
+    public static String toFurigana(Token token) {
+        // Add furigana to kanji words only
+        if(token.getSurface().matches("[\\u4e00-\\u9faf]+.*")) {
+            String reading = Utils.toHiragana(token.getKana());
+            String surface = token.getSurface();
+
+            // 引[きこもり]
+            for (int i = reading.length(); i > 0; i--) {
+                if (reading.charAt(i - 1) == surface.charAt(surface.length() - 1)) {
+                    surface = surface.substring(0, surface.length() - 1);
+                    reading = reading.substring(0, reading.length() - 1);
+                } else {
+
+                    break;
+                }
+            }
+
+            String finalReading = Utils.toHiragana(token.getKana());
+            String tail = finalReading.substring(reading.length(), finalReading.length());
+
+            return surface + "[" + reading + "]" + tail;
+        } else {
+            return token.getSurface();
+        }
     }
 
 }

--- a/src/miniFrequencyData.java
+++ b/src/miniFrequencyData.java
@@ -24,7 +24,9 @@ class miniFrequencyData
     private HashMap<String, Integer> frequency = new HashMap<>();
     private HashMap<String, HashMap<String, Integer>> spellings = new HashMap<>();
     private HashMap<String, Integer> location = new HashMap<>();
-    void addEvent(String id, Integer extra)
+    private HashMap<String, String> line = new HashMap<>();
+
+    void addEvent(String id, Integer extra, String originalLine)
     {
         String name;
         String identity;
@@ -49,6 +51,8 @@ class miniFrequencyData
         {
             frequency.put(identity, 1);
             location.put(identity, extra);
+            line.put(identity, originalLine);
+
         }
         
         if(Main.pull_out_spellings || Main.lexeme_only)
@@ -78,11 +82,15 @@ class miniFrequencyData
             Integer frequency = v.getValue();
             String identity = v.getKey();
             Integer location = this.location.get(v.getKey());
+            String line = this.line.get(v.getKey());
             
             Fact fact = new Fact(frequency, identity);
 
             if(location >= 0)
                 fact.id += "\t"+location.toString();
+
+            if(line != null)
+                fact.id += "\t"+line;
             
             if(Main.pull_out_spellings || Main.lexeme_only)
             {

--- a/src/miniFrequencyData.java
+++ b/src/miniFrequencyData.java
@@ -26,7 +26,7 @@ class miniFrequencyData
     private HashMap<String, Integer> location = new HashMap<>();
     private HashMap<String, String> line = new HashMap<>();
 
-    void addEvent(String id, Integer extra, String originalLine)
+    void addEvent(String id, Integer extra, String extraFields)
     {
         String name;
         String identity;
@@ -51,7 +51,7 @@ class miniFrequencyData
         {
             frequency.put(identity, 1);
             location.put(identity, extra);
-            line.put(identity, originalLine);
+            line.put(identity, extraFields);
 
         }
         


### PR DESCRIPTION
I was inspired my Nukemarines sentence mining method [here](https://www.reddit.com/r/LearnJapanese/comments/62y85h/japanese_version_of_harry_potter_book_1/) and decided to add some new features to support and enhance this method.

This adds a few new optional parameters:

- Index of sentence for TSV input
- Kanji words only
- Including the furigana reading with cloze for Anki
- Append the original line so you don't need to open excel to merge the files together

Please check the code as I'm not really a Java developer but I think its working very well and have automatically generated cards like this, and also definitions when combined with Epwing2Anki:

![sentence-mining](https://user-images.githubusercontent.com/283316/29242133-671bc746-7fca-11e7-80f5-4fd6de397dbc.PNG)

![sentence-mining-writing](https://user-images.githubusercontent.com/283316/29242164-f2ca02a8-7fca-11e7-8a39-d9f454043f80.PNG)
